### PR TITLE
feat: add GET/api/tweets/:tweetid api

### DIFF
--- a/controllers/tweet-controller.js
+++ b/controllers/tweet-controller.js
@@ -7,6 +7,10 @@ const tweetController = {
   postTweet: (req, res, next) => {
     tweetServices.postTweet(req, (err, data) =>
       err ? next(err) : res.status(200).json({ status: 'success', data }))
-  }
+  },
+  getTweet: (req, res, next) => {
+    tweetServices.getTweet(req, (err, data) =>
+      err ? next(err) : res.status(200).json(data)) // 應測試要求要第一層就能找到description只好拿掉 status
+  },
 }
 module.exports = tweetController

--- a/routes/index.js
+++ b/routes/index.js
@@ -10,6 +10,7 @@ const { authenticated, authenticatedUser } = require('../middleware/api-auth')
 router.get('/', (req, res) => {
   res.send('Hello World!')
 })
+router.get('/api/tweets/:tweetId', authenticated, tweetController.getTweet)
 router.post('/api/tweets', authenticated, tweetController.postTweet)
 router.get('/api/tweets', authenticated, tweetController.getTweets)
 router.post('/api/users', userController.signUp)


### PR DESCRIPTION
新增 GET/api/tweets/:tweetid api 瀏覽個別推文, 資料包含其回覆 喜歡 推文者資訊 並通過測試 (44:15)
<img width="1287" alt="截圖 2022-02-23 下午12 04 36" src="https://user-images.githubusercontent.com/43169057/155260071-05ca385b-6130-4133-a137-8bbcdb6e8d03.png">
